### PR TITLE
Update default.meta

### DIFF
--- a/metadata/default.meta
+++ b/metadata/default.meta
@@ -1,7 +1,7 @@
 []
-access = read : [ * ], write : [ admin ]
+access = read : [ * ], write : [ admin,sc_admin ]
 export = system
 
 [views]
-access = read : [ * ], write : [ admin ]
+access = read : [ * ], write : [ admin,sc_admin ]
 export = none


### PR DESCRIPTION
Updated default.meta to eliminate warning from AppInspect related to Splunk Cloud.  Essentially we needed to add sc_admin to the default permission set in addition to admin which was already present.